### PR TITLE
Add argument to number headings in table of contents

### DIFF
--- a/bin/generate-md
+++ b/bin/generate-md
@@ -86,6 +86,6 @@ var list = new List(),
 
 list.add(argv.input);
 
-console.log(argv, list.files.map(function(i){ return i.name; }));
+// console.log(argv, list.files.map(function(i){ return i.name; }));
 
 runner(list, argv);

--- a/bin/generate-md
+++ b/bin/generate-md
@@ -14,7 +14,9 @@ var knownOpts = {
   'output': path,
   'runner': path,
   'command': String,
-  'asset-dir': String
+  'asset-dir': String,
+  // formatting
+  'number-toc': Boolean
 };
 
 var argv = nopt(knownOpts, {}, process.argv, 2);
@@ -84,6 +86,6 @@ var list = new List(),
 
 list.add(argv.input);
 
-// console.log(argv, list.files.map(function(i){ return i.name; }));
+console.log(argv, list.files.map(function(i){ return i.name; }));
 
 runner(list, argv);

--- a/lib/file-tasks/apply-template.js
+++ b/lib/file-tasks/apply-template.js
@@ -26,14 +26,34 @@ Wrap.prototype._transform = function(chunk, encoding, done) {
 Wrap.prototype._flush = function(done) {
   var self = this;
   // at the end of input, process the whole stream
-
+ 
+  var chapters = [0,0,0,0,0];
+  function incrementChapter(pos){
+    if(pos<0){return;}
+    chapters[pos-1]++;
+    while(pos < 5){
+      chapters[pos] = 0;
+      pos++;
+    }
+  }
+  function getChapter(){
+    return chapters.join('.').replace(/([.0]*$)/,'');
+  }
+  
+  var numberToc = this.options.numberToc;
   this.options.meta.toc = [];
   this.options.meta.content = this.buffer.replace(/<(ul|ol)>/g, '<$1 class="list">')
       .replace(/<pre><code[^>]*>([\s\S]*?)<\/code><\/pre>/mg, '<pre class="prettyprint">$1</pre>')
       .replace(/<p><img([^>]*)>\s*<\/p>/g, '<p class="img-container"><img$1></p>')
       .replace(/<(h[1-5])[^>]*>([^<]*)<\/h[1-5]>/g, function(match, p1, p2) {
         var name = p2.toLowerCase().replace(/[^a-z0-9]/g, '_');
-        self.options.meta.toc.push({ title: p2, id: name });
+        var chDepth = parseInt(p1.charAt(1));
+        incrementChapter(chDepth-1);
+        if(numberToc == false){
+          self.options.meta.toc.push({ title: p2, id: name });
+        } else {
+          self.options.meta.toc.push({ title: getChapter()!='' ? getChapter()+' - '+p2 : p2, id: name });
+        }
         return '<a name="'+name+'"></a><'+p1+'>'+p2+'<a class="anchorlink" href="#'+name+'"></a></'+p1+'>';
       });
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -61,7 +61,8 @@ module.exports = function(list, options) {
       function() {
         return applyTemplate({
           template: templateContent,
-          meta: meta
+          meta: meta,
+          numberToc: options['number-toc'] ? options['number-toc'] : false
         });
       }
     ];

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,10 @@ You will also need to include [one of the highlight.js CSS style sheets](http://
 
 `--asset-dir <path>`: Normally, the asset directory is assumed to be `./assets/` in the same folder the `--layout` file is. You can override it to a different asset directory explicitly with `--asset-dir`, which is useful for builds where several directories use the same layout but different asset directories.
 
+## New! --number-toc
+
+`--number-toc`: Normally `{{toc}}` will produce a list of headings without any indication as to their rank. By providing this argument the generated Table of Contents will include numerical hierarchical descriptors on the left of each heading in the Table of Contents only.
+
 ## Metadata support
 
 You can also add a file named `meta.json` to the folder from which you run `generate-md`.


### PR DESCRIPTION
Added `--number-toc` as an argument.

Normally `{{toc}}` will produce a list of headings without any indication as to their rank. By providing this argument the generated Table of Contents will include numerical hierarchical descriptors on the left of each heading in the Table of Contents only.

Example:
	# TitleA
	## HeadingA
	### HeadingB
	## HeadingC
	## HeadingD
	# TitleB
	## HeadingE
	### HeadingF

Produces:
	TitleA
	1 - HeadingA
	1.1 - HeadingB
	2 - HeadingC
	3 - HeadingD
	TitleB
	1 - HeadingE
	1.1 - HeadingF