### PR TITLE
Added onDone wrapper to render() to wait till assets are copied

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -6,6 +6,17 @@ var fs = require('fs'),
     stream = require('./stream');
 
 module.exports = function(argv, onDone) {
+
+    var finalDone = onDone || function(){};
+    var doneCount = 0;
+    var expectedDoneCount = 2;
+    onDone = function() {
+        if (++doneCount == expectedDoneCount) {
+            finalDone();
+        }
+    };
+
+
   // --export
   if (argv['export']) {
     pi.fromArray(
@@ -19,11 +30,7 @@ module.exports = function(argv, onDone) {
           console.log('Copy layout file', filename, '=>', target);
           return target;
         }))
-        .pipe(pi.devnull().once('finish', function() {
-          if (onDone) {
-            onDone();
-          }
-        }));
+        .pipe(pi.devnull().once('finish', finalDone));
     return;
   }
 
@@ -64,11 +71,7 @@ module.exports = function(argv, onDone) {
       pi.head([
         stream.read(),
         pipeline(argv),
-        stream.write().once('finish', function() {
-          if (onDone) {
-            onDone();
-          }
-        })
+        stream.write().once('finish', onDone)
       ])
     )
   ]));
@@ -87,7 +90,7 @@ module.exports = function(argv, onDone) {
           console.log('Copy asset file', filename, '=>', target);
           return target;
         }))
-        .pipe(pi.devnull());
+        .pipe(pi.devnull().once('finish', onDone));
   } else {
     console.log('Assets path does not exist: ' + assetDir + ', so no assets were copied.');
   }


### PR DESCRIPTION
I tried to use the code in grunt and was getting an error because it would quit before all the assets were copied.

This change adds a handler to the end of the asset copy routine and makes sure the asset copy and the markdown conversion are complete before onDone is called.