### PR TITLE
Bumping markdown-stream-utils to 1.2.0 (adds YAML support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "handlebars": "~4.0.3",
-    "markdown-stream-utils": "~1.1.2",
+    "markdown-stream-utils": "~1.2.0",
     "mkdirp": "~0.5.1",
     "pipe-iterators": "~1.1.0",
     "resolve": "~1.1.6",


### PR DESCRIPTION
There were no changes in the tests, all passing.

I was already using this for YAML support on my own documents so it "work on my machine" :stuck_out_tongue: 