### PR TITLE
Update resolve-args.js

### DIFF
--- a/lib/resolve-args.js
+++ b/lib/resolve-args.js
@@ -47,16 +47,19 @@ module.exports = function(argv) {
     argv['export'] = argv.layout;
   }
 
-  // set up partials and helpers directories
-  var layoutBase = path.dirname(argv.template);
-  ['partials', 'helpers'].forEach(function(name) {
-    if (argv[name]) {
-      argv[name] = path.resolve(process.cwd(), argv[name]);
-    } else if (fs.existsSync(layoutBase + '/' + name)) {
-      // if the folder exists in the layout, use it automatically
-      argv[name] = layoutBase + '/' + name;
-    }
-  });
+  // in node.js 6.x path.dirname expects a string
+  if(argv.template && typeof argv.template === 'string')
+    // set up partials and helpers directories
+    var layoutBase = path.dirname(argv.template);
+    ['partials', 'helpers'].forEach(function(name) {
+      if (argv[name]) {
+        argv[name] = path.resolve(process.cwd(), argv[name]);
+      } else if (fs.existsSync(layoutBase + '/' + name)) {
+        // if the folder exists in the layout, use it automatically
+        argv[name] = layoutBase + '/' + name;
+      }
+    });
+  }
 
   // parse --highlight-<extension>
   var hl = {};


### PR DESCRIPTION
Hi,

it seems like in node.js 6.x, path.dirname() requires a string as argument and throws an error otherwise.
On v6.0.0 I get:

```
path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1324:5)
    at module.exports (/Users/maximumstock/dev/hex/hexsales-api/node_modules/markdown-styles/lib/resolve-args.js:51:24)
```

To not have any side effects, I just added some type checking for at line 51, which invokes path.dirname(argv.template) which will always be undefined because of line 19.

Edit: Here are the links to the documentation: [5.11](https://nodejs.org/docs/latest-v5.x/api/path.html#path_path_dirname_p) - [6.0.0](https://nodejs.org/api/path.html#path_path_dirname_path)