### PR TITLE
fixed mixu-page not loading google font

### DIFF
--- a/layouts/mixu-page/assets/css/style.css
+++ b/layouts/mixu-page/assets/css/style.css
@@ -1,4 +1,4 @@
-@import url(//fonts.googleapis.com/css?family=PT+Sans);
+@import url(https://fonts.googleapis.com/css?family=PT+Sans);
 
 body {
   font-family: 'PT Sans', Helvetica, 'Helvetica Neuve', Arial, Tahoma, sans-serif;


### PR DESCRIPTION
It previously defaulted to file:// protocol which caused the page to load until the request timed out.