### PR TITLE
Allow generating HTLM compatible pathes on Windows OS

### DIFF
--- a/lib/set-output-path.js
+++ b/lib/set-output-path.js
@@ -23,6 +23,9 @@ module.exports = function(opts) {
 
     item.assetsRelative = path.relative(outputDir, opts['asset-path'] || opts.output + '/assets');
 
+    item.relative = item.relative.replace(/\\/g, '/');
+    item.assetsRelative = item.assetsRelative.replace(/\\/g, '/');
+
     return item;
   });
 };


### PR DESCRIPTION
If you generate your HTML on Windows, your `{{asset 'path'}}` can be a little messy, mixing slashes and backslashes, like `..\..\assets/path`.

It's just a naive correction. Make sure it suits you.