### PR TITLE
Fix single file support and move single file detection in resolve-args

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -34,12 +34,8 @@ module.exports = function(argv, onDone) {
     return;
   }
 
-  var isSingleFile = fs.statSync(argv.input).isFile();
-  argv.isSingleFile = isSingleFile;
-
-  pi.fromArray(
-    glob.sync(isSingleFile ? argv.input : argv.input.replace(new RegExp(path.sep + '$'), '') + '/**')
-    ).pipe(pi.head([
+  var files = argv.isSingleFile ? [argv.input] : glob.sync(argv.input.replace(new RegExp(path.sep + '$'), '') + '/**');
+  pi.fromArray(files).pipe(pi.head([
 
     pi.filter(function(filename) {
       var stat = fs.statSync(filename);

--- a/lib/resolve-args.js
+++ b/lib/resolve-args.js
@@ -7,6 +7,7 @@ var layoutDir = __dirname + '/../layouts/';
 module.exports = function(argv) {
   // defaults
   argv.input = path.resolve(process.cwd(), argv.input || './input/');
+  argv.isSingleFile = fs.statSync(argv.input).isFile();
   argv.output = path.resolve(process.cwd(), argv.output || './output/');
   if (!argv.layout) {
     if (argv['export']) {


### PR DESCRIPTION
Hi Mikito,
I was trying to input a single file and it wasn't working. (On Windows)
This commit would ensure the detection happens early and that the _single-file_ gets in the output.

I also created a version that, with a single file only, it embeds the css inside the html with the "--flat" argument:
https://github.com/josimard/markdown-styles/commit/d5951b37936e46b4d125234db7decfca8fcbf2d0

It it not working with other layouts assets such as fonts, but it might give you an idea. 
I am not that good with pipe/streams so I had to move some code around to understand better render.js.

Cheers
- Jonathan